### PR TITLE
Replace usage of Master with Main

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "author": "Adam J. Jolicoeur",
   "description": "The Portfolio of Adam J. Jolicoeur",
-  "name": "The Portfolio of Adam J. Jolcoeur",
+  "name": "The Portfolio of Adam J. Jolicoeur",
   "short_name": "Adam J.",
   "lang": "en-US",
   "display": "standalone",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adam J. Jolicoeur",
   "homepage": "https://www.adamjolicoeur.com",
   "license": "Apache-2.0",
-  "licenseUrl": "https://github.com/mindreeper2420/mindreeper2420.github.io/blob/master/LICENSE",
+  "licenseUrl": "https://github.com/mindreeper2420/mindreeper2420.github.io/blob/main/LICENSE",
   "scripts": {
     "dev": "gulp serve",
     "build": "gulp build",


### PR DESCRIPTION
Replace the usage of `master` with `main`. This precedes updating the primary branch in the repo settings.