### PR TITLE
patch: remove automerge based on labels

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,9 +27,4 @@ jobs:
         uses: "pascalgn/automerge-action@v0.9.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "Ready to merge"
-          MERGE_REMOVE_LABELS: "Ready to merge, in progress"
-          MERGE_METHOD: squash
-          MERGE_DELETE_BRANCH: true
-          UPDATE_LABELS: "Ready to merge"
-          UPDATE_METHOD: merge
+          MERGE_LABELS: "!in progress!,!blocked,!question,!duplicate,!invalid,!Stale PR,!wontfix"


### PR DESCRIPTION
Remove the ability for labels to automatically merge PRs, due to the fact that they do not subsequently run `release-drafter`, as GitHub Actions do not kick off other GitHub Actions.